### PR TITLE
fix-booleanfield-unique: Update models.py

### DIFF
--- a/plans/base/models.py
+++ b/plans/base/models.py
@@ -78,7 +78,7 @@ class AbstractPlan(BaseMixin, OrderedModel):
         help_text=_('Both "Unknown" and "No" means that the plan is not default'),
         default=None,
         db_index=True,
-        unique=True,
+        unique=False,
         null=True,
     )
     available = models.BooleanField(


### PR DESCRIPTION
    default = models.BooleanField(
        help_text=_('Both "Unknown" and "No" means that the plan is not default'),
        default=None,
        db_index=True,
        unique=True,
        null=True,
    )

unique=True - incorrect. BooleanField can't be uniqie.